### PR TITLE
Create docker images for Airflow

### DIFF
--- a/.github/workflows/airflow-docker.yml
+++ b/.github/workflows/airflow-docker.yml
@@ -1,0 +1,30 @@
+name: Validate Airflow Docker images
+
+on:
+  push:
+    branches-ignore:
+      - 'master'
+    paths:
+      - 'plugins/airflow/docker/**'
+
+jobs:
+  validate:
+    name: Validate Airflow Docker images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        airflow-version: [1.10.2, 1.10.3, 1.10.6, 1.10.9]
+        include:
+          - airflow-version: 1.10.2, 1.10.3
+            airflow-extras: 'gcp_api,postgres'
+          - airflow-version: 1.10.6, 1.10.9
+            airflow-extras: 'gcp,postgres'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Docker build
+        env:
+          AIRFLOW_VERSION: ${{ matrix.airflow-version }}
+          AIRFLOW_EXTRAS: ${{ matrix.airflow-extras }}
+        run: cd plugins/airflow/docker && make build

--- a/.github/workflows/airflow-docker.yml
+++ b/.github/workflows/airflow-docker.yml
@@ -1,16 +1,14 @@
-name: Validate Airflow Docker images
+name: Create Airflow Docker images
 
 on:
   push:
-    branches-ignore:
-      - 'master'
     paths:
       - 'plugins/airflow/docker/**'
       - '.github/workflows/airflow-docker.yml'
 
 jobs:
   validate:
-    name: Validate Airflow Docker images
+    name: Create Airflow Docker images
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,3 +32,16 @@ jobs:
           AIRFLOW_VERSION: ${{ matrix.airflow-version }}
           AIRFLOW_EXTRAS: ${{ matrix.airflow-extras }}
         run: cd plugins/airflow/docker && make build
+
+      - name: Docker login
+        if: github.ref == 'refs/heads/master'
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+      - name: Docker push
+        if: github.ref == 'refs/heads/master'
+        env:
+          AIRFLOW_TAG: ${{ matrix.airflow-version }}
+        run: make push

--- a/.github/workflows/airflow-docker.yml
+++ b/.github/workflows/airflow-docker.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
     paths:
       - 'plugins/airflow/docker/**'
+      - '.github/workflows/airflow-docker.yml'
 
 jobs:
   validate:

--- a/.github/workflows/airflow-docker.yml
+++ b/.github/workflows/airflow-docker.yml
@@ -15,10 +15,15 @@ jobs:
       matrix:
         airflow-version: [1.10.2, 1.10.3, 1.10.6, 1.10.9]
         include:
-          - airflow-version: 1.10.2, 1.10.3
+          - airflow-version: 1.10.2
             airflow-extras: 'gcp_api,postgres'
-          - airflow-version: 1.10.6, 1.10.9
+          - airflow-version: 1.10.3
+            airflow-extras: 'gcp_api,postgres'
+          - airflow-version: 1.10.6
             airflow-extras: 'gcp,postgres'
+          - airflow-version: 1.10.9
+            airflow-extras: 'gcp,postgres'
+
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/plugins/airflow/docker/Dockerfile
+++ b/plugins/airflow/docker/Dockerfile
@@ -1,0 +1,10 @@
+ARG IMAGE=python:3.7-stretch
+FROM ${IMAGE}
+
+RUN apt-get update
+RUN apt-get install openjdk-8-jre -y
+
+ENV AIRFLOW_GPL_UNIDECODE="yes"
+ARG AIRFLOW_VERSION=1.10.6
+ARG AIRFLOW_EXTRAS=gcp,postgres
+RUN pip install apache-airflow[${AIRFLOW_EXTRAS}]==${AIRFLOW_VERSION}

--- a/plugins/airflow/docker/Makefile
+++ b/plugins/airflow/docker/Makefile
@@ -1,0 +1,17 @@
+.SILENT: ;
+.DEFAULT_GOAL :=  help
+include ../../help/help.mk
+
+ifndef AIRFLOW_VERSION
+AIRFLOW_VERSION := 1.10.6
+endif
+
+ifndef AIRFLOW_EXTRAS
+AIRFLOW_EXTRAS := gcp,postgres
+endif
+
+build: ## Builds the docker image given AIRFLOW_VERSION and AIRFLOW_EXTRAS
+	docker build --build-arg IMAGE=python:3.7-stretch \
+		--build-arg AIRFLOW_VERSION=$(AIRFLOW_VERSION) \
+		--build-arg AIRFLOW_EXTRAS=$(AIRFLOW_EXTRAS) \
+		-t unacast/airflow:$(AIRFLOW_VERSION) .

--- a/plugins/airflow/docker/Makefile
+++ b/plugins/airflow/docker/Makefile
@@ -12,8 +12,13 @@ ifndef AIRFLOW_EXTRAS
 AIRFLOW_EXTRAS := gcp,postgres
 endif
 
+.PHONY: build
 build: ## Builds the docker image given AIRFLOW_VERSION and AIRFLOW_EXTRAS
 	docker build --build-arg IMAGE=python:3.7-stretch \
 		--build-arg AIRFLOW_VERSION=$(AIRFLOW_VERSION) \
 		--build-arg AIRFLOW_EXTRAS=$(AIRFLOW_EXTRAS) \
 		-t unacast/airflow:$(AIRFLOW_VERSION) .
+.PHONY: push
+push: ## Push to dockerhub given AIRFLOW_TAG
+	$(if $(value AIRFLOW_TAG),, $(error AIRFLOW_TAG environment variable is not set.))
+	docker push unacast/airflow:$(AIRFLOW_TAG)

--- a/plugins/airflow/docker/Makefile
+++ b/plugins/airflow/docker/Makefile
@@ -2,6 +2,8 @@
 .DEFAULT_GOAL :=  help
 include ../../help/help.mk
 
+# We default to 1.10.6, which is the highest version supported
+# by Google Cloud Composer at the moment
 ifndef AIRFLOW_VERSION
 AIRFLOW_VERSION := 1.10.6
 endif


### PR DESCRIPTION
As to have a faster startup in Airflow, it is beneficial to have some docker images.

This PR will create docker images with Python version 3.7 and Airflow 1.10.2, 1.10.3, 1.10.6 and 1.10.9 with Java installed as well.